### PR TITLE
Re-render chart on update and deletion of time entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+Re-render chart on update and deletion of time entries (#22)
+
 ## v1.8.3
 
 - Use color from company theme

--- a/src/background/timechimp.ts
+++ b/src/background/timechimp.ts
@@ -45,12 +45,19 @@ chrome.webRequest.onCompleted.addListener(
  * Listen for API calls related to time entries.
  */
 chrome.webRequest.onCompleted.addListener(
-    (request) => sendMessage(request.tabId, { type: 'refresh' }),
+    function (request) {
+        if (request.method === 'GET') {
+            // Exclude GET requests as that could trigger endless loops
+            return;
+        }
+
+        return sendMessage(request.tabId, { type: 'refresh' });
+    },
     {
         urls: [
-            `${API_URL}/api/time`,
-            `${API_URL}/api/time/put`,
-            `${API_URL}/api/time/delete?*`,
+            `${API_URL}/api/time`,        // Using POST method when adding a new entry
+            `${API_URL}/api/time/*`,      // Using DELETE or PUT method when deleting or updating an entry
+            `${API_URL}/api/time/copy/*`, // Using POST method when copying entry
         ],
     },
 );

--- a/src/background/timechimp.ts
+++ b/src/background/timechimp.ts
@@ -55,8 +55,8 @@ chrome.webRequest.onCompleted.addListener(
     },
     {
         urls: [
-            `${API_URL}/api/time`,        // Using POST method when adding a new entry
-            `${API_URL}/api/time/*`,      // Using DELETE or PUT method when deleting or updating an entry
+            `${API_URL}/api/time`, // Using POST method when adding a new entry
+            `${API_URL}/api/time/*`, // Using DELETE or PUT method when deleting or updating an entry
             `${API_URL}/api/time/copy/*`, // Using POST method when copying entry
         ],
     },


### PR DESCRIPTION
This pull request updates the `chrome.webRequest.onCompleted.addListener` logic in `src/background/timechimp.ts` to improve the handling of API calls related to time entries. The changes prevent endless loops caused by GET requests and refine the URL matching for different API operations.

### Key changes:

#### Improved request handling:
* Updated the callback function to exclude GET requests to avoid triggering endless loops.

#### Refined URL matching:
* Adjusted the `urls` array to include more specific patterns for DELETE, PUT, and POST methods, ensuring better alignment with the API's operations:
  - Added support for `/api/time/*` for DELETE or PUT methods.
  - Added support for `/api/time/copy/*` for POST methods.

Fixes #3 