### PR TITLE
Feature: Add release workflow to create release once tag is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,24 @@ on: [ push ]
 jobs:
   checks:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - run: ./check-versions.sh
-      - uses: actions/setup-node@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm run type-check
-      - run: npm run lint
-      - run: npm run build
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: build
+      - name: Build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          awk "/^## \\[?${{ github.ref_name }}\\]? /{flag=1;next}/^## /{flag=0}flag" CHANGELOG.md > ${{ github.workspace }}-CHANGELOG.txt
+
+      - name: Build artifacts
+        run: |
+          npm install 
+          npm run build
+          zip -r ${{ github.ref_name }}-chrome.zip build_chrome/*
+          zip -r ${{ github.ref_name }}-firefox.zip build_firefox/*
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          body_path: ${{ github.workspace }}-CHANGELOG.txt
+          files: |
+            ${{ github.ref_name }}-chrome.zip
+            ${{ github.ref_name }}-firefox.zip
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Verify versions
+        run: ./check-versions.sh
+
       - name: Generate changelog
         id: changelog
         run: |
           awk "/^## \\[?${{ github.ref_name }}\\]? /{flag=1;next}/^## /{flag=0}flag" CHANGELOG.md > ${{ github.workspace }}-CHANGELOG.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Build artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        # The below run steps assumes the changelog is in the format of https://keepachangelog.com/en/1.1.0/
         run: |
           awk "/^## \\[?${{ github.ref_name }}\\]? /{flag=1;next}/^## /{flag=0}flag" CHANGELOG.md > ${{ github.workspace }}-CHANGELOG.txt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 - Re-render chart on update and deletion of time entries (#22)
 ### Added
-- Add release workflow to create release once tag is pushed
+- Add release workflow to create release once tag is pushed (#23)
 
 ## [v1.8.3] - 2025-04-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,72 +4,74 @@
 ### Fixed
 Re-render chart on update and deletion of time entries (#22)
 
-## v1.8.3
-
+## [v1.8.3] - 2025-04-24
+### Fixed
 - Use color from company theme
 
-## v1.8.2
-
+## [v1.8.2] - 2024-06-28
+### Fixed
 - Fix extension after changes in the TimeChimp HTML structure.
 
-## v1.8.1
-
+## [v1.8.1] - 2024-02-28
+### Added
 - Add "Ouderschapsverlof" to leave tasks.
 
-## v1.8.0
-
+## [v1.8.0] - 2024-02-06
+### Added
 - Show billability percentage in chart.
 
-## v1.7.0
-
+## [v1.7.0] - 2024-02-03
+### Added
 - Add mode for viewing chart and stats relative to contract hours.
 - Add loading indicator.
 
-## v1.6.0
-
+## [v1.6.0] - 2024-02-03
+### Added
 - Load theme color for billable section of the chart from company configuration.
 
-## v1.5.2
-
+## [v1.5.2] - 2024-01-04
+### Fixed
 - Fix week ordering between years.
 
-## v1.5.1
-
+## [v1.5.1] - 2023-11-10
+### Added
 - Add "Tijd voor tijd" to leave tasks.
 
-## v1.5.0
-
+## [v1.5.0] - 2023-11-10
+### Fixed
 - Exclude leave tasks ("Bijzonder verlof", "Feestdag", "Verlof") from billability calculation.
+### Added
 - Show leave hours in tooltip.
 
-## v1.4.0
-
+## [v1.4.0] - 2023-11-10
+### Added
 - Show actual hours next to billability percentages in tooltip.
 
-## v1.3.1
-
+## [v1.3.1] - 2023-11-10
+### Fixed
 - Fix chart breaking when changing page or switching time entries view.
 
-## v1.3.0
-
+## [v1.3.0] - 2023-11-10
+### Fixed
 - Improve setup and remove unnecessary permissions.
 - Fix billability rolling average calculation.
 - Fix chart not showing for non-admin users.
 
-## v1.2.0
-
+## [v1.2.0] - 2023-11-10
+### Added
 - Show total hours worked on the chart x-axis and in the tooltip.
 
-## v1.1.0
-
+## [v1.1.0] - 2023-11-10
+### Added
 - Refresh the chart when adding, editing, or deleting time entries.
 - Update the chart with an animation instead of recreating it on changes.
+### Fixed
 - Fix some bugs with week switching and improve overall date handling.
 
-## v1.0.1
-
+## [v1.0.1] - 2023-11-10
+### Fixed
 - Fixed a unauthorized API call to break the chart for non-admin users.
 
-## v1.0.0
-
+## [v1.0.0] - 2023-11-10
+### Added
 Initial release! 📊

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 ### Fixed
-Re-render chart on update and deletion of time entries (#22)
+- Re-render chart on update and deletion of time entries (#22)
+### Added
+- Add release workflow to create release once tag is pushed
 
 ## [v1.8.3] - 2025-04-24
 ### Fixed


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for automating releases and reformats the `CHANGELOG.md` file to include proper versioning and dates. These changes aim to streamline the release process and improve the readability of the changelog.

### Automation for Releases:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R39): Added a new GitHub Actions workflow to automate the release process. This includes generating a changelog, building artifacts for Chrome and Firefox, and creating a GitHub release with the associated files.

### Changelog Improvements:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL7-R76): Reformatted the changelog to include version numbers with corresponding release dates and grouped changes under "Added" and "Fixed" sections for better clarity.

Fixes #21 