### PR TITLE
fix: Correct the firefox zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           npm install 
           npm run build
           zip -r ${{ github.ref_name }}-chrome.zip build_chrome/*
-          zip -r ${{ github.ref_name }}-firefox.zip build_firefox/*
+          cd build_firefox && zip -r ../${{ github.ref_name }}-firefox.zip . && cd ..
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Correct firefox zip (#27)
+
 ## [v2.0.0]
 ### Fixed
 - Re-render chart on update and deletion of time entries (#22)


### PR DESCRIPTION
During release it was found that Firefox requires the manifest.json at root level instead inside a folder